### PR TITLE
Add commit-based resource naming

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Terraform Plan ou Apply
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/gui" ]; then
-            terraform apply -auto-approve -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}"
+            terraform apply -auto-approve -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" -var="commit_id=${GITHUB_SHA}"
           else
-            terraform plan -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}"
+            terraform plan -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" -var="commit_id=${GITHUB_SHA}"
           fi
         working-directory: ./terraform
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,12 +7,12 @@ provider "google" {
 
 
 resource "google_compute_network" "vpc_network" {
-  name = "${var.instance_name}-vpc-v2"
+  name = "${var.instance_name}-${substr(var.commit_id,0,8)}-vpc"
   auto_create_subnetworks = true
 }
 
 resource "google_compute_firewall" "allow_ports" {
-  name    = "allow-ssh-grafana-prometheus"
+  name    = "allow-ssh-grafana-prometheus-${substr(var.commit_id,0,8)}"
   network = google_compute_network.vpc_network.name
 
   allow {
@@ -24,7 +24,7 @@ resource "google_compute_firewall" "allow_ports" {
 }
 
 resource "google_compute_instance" "vm_instance" {
-  name         = var.instance_name
+  name         = "${var.instance_name}-${substr(var.commit_id,0,8)}"
   machine_type = "e2-medium"
   zone         = var.zone
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,3 +27,9 @@ variable "ssh_public_key" {
   type        = string
   default     = ""
 }
+
+variable "commit_id" {
+  description = "Commit ID used to uniquely name resources"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add new variable `commit_id` for dynamic resource names
- update resource names to include the commit prefix
- pass commit SHA from the GitHub workflow to Terraform

## Testing
- `terraform fmt -check ./terraform` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844afb648d08331914b00aaf2f0a7b7