### PR TITLE
Add Terraform cleanup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,8 @@ on:
 jobs:
   terraform-and-ansible:
     runs-on: ubuntu-latest
+    env:
+      DESTROY_AFTER_RUN: ${{ secrets.DESTROY_AFTER_RUN || 'false' }}
     steps:
       - name: Checkout código
         uses: actions/checkout@v4
@@ -22,8 +24,11 @@ jobs:
         run: terraform init
         working-directory: ./terraform
 
+      - name: Set commit ID
+        run: echo "COMMIT_ID=${GITHUB_SHA}" >> $GITHUB_ENV
+
       - name: Terraform Apply
-        run: terraform apply -auto-approve -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" -var="commit_id=${GITHUB_SHA}"
+        run: terraform apply -auto-approve -var="ssh_public_key=${{ secrets.SSH_PUBLIC_KEY }}" -var="commit_id=${{ env.COMMIT_ID }}"
         working-directory: ./terraform
 
       - name: Instalar Ansible
@@ -52,4 +57,9 @@ jobs:
         run: |
           VM_IP=$(terraform output -raw instance_ip)
           echo "Grafana disponível em: http://$VM_IP"
+        working-directory: ./terraform
+
+      - name: Destroy infrastructure
+        if: env.DESTROY_AFTER_RUN == 'true'
+        run: terraform destroy -auto-approve -var="commit_id=${{ env.COMMIT_ID }}"
         working-directory: ./terraform

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,9 @@
 name: Terraform Plan & Deploy Pipeline
 on:
   push:
+    branches: [main, gui, dev]
   pull_request:
+    branches: [main, gui, dev]
 jobs:
   terraform-and-ansible:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- free cloud resources after each pipeline run
- fix Terraform destroy step to use commit ID
- require `DESTROY_AFTER_RUN` secret to trigger the cleanup step

## Testing
- `terraform fmt -check ./terraform` *(fails: command not found)*
- `ansible-lint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d84bcdec8331993415c7b1105fd6